### PR TITLE
Simplification of `src/core/adapters/rotate.rs` -> `Generator<3> for Rotate<3, 3, G>` and `Generator<4> for Rotate<4, 6, G>`

### DIFF
--- a/src/core/adapters/rotate.rs
+++ b/src/core/adapters/rotate.rs
@@ -89,49 +89,71 @@ impl<G: Generator<4>> Generator<4> for Rotate<4, 6, G> {
         let cos_epsilon = self.rotation[4].cos();
         let sin_digamma = self.rotation[5].sin();
         let cos_digamma = self.rotation[5].cos();
-        // i am too lazy to simplify this, i cannot verify correctness easily either
-        let x1 = cos_alpha * cos_beta * cos_gamma;
-        let y1 = -cos_epsilon * sin_alpha * cos_delta
-            - cos_epsilon * cos_alpha * sin_beta * sin_delta
-            - sin_epsilon * cos_alpha * cos_beta * sin_gamma;
-        let z1 = -sin_alpha * (-sin_epsilon * cos_delta * sin_digamma - sin_delta * cos_digamma)
-            - cos_alpha
-                * sin_beta
-                * (cos_delta * cos_digamma - sin_epsilon * sin_delta * sin_digamma)
-            - cos_epsilon * cos_alpha * cos_beta * sin_gamma * sin_digamma;
-        let w1 = -sin_alpha * (sin_delta * sin_digamma - sin_epsilon * cos_delta * cos_digamma)
-            - cos_alpha
-                * sin_beta
-                * (-sin_epsilon * sin_delta * cos_digamma - cos_delta * sin_digamma)
-            - cos_epsilon * cos_alpha * cos_beta * sin_gamma * cos_digamma;
-        let x2 = sin_alpha * cos_beta * cos_gamma;
-        let y2 = -cos_epsilon * sin_alpha * sin_beta * sin_delta
-            - sin_epsilon * sin_alpha * cos_beta * sin_gamma
-            + cos_epsilon * cos_alpha * cos_delta;
-        let z2 = -sin_alpha
-            * sin_beta
-            * (cos_delta * cos_digamma - sin_epsilon * sin_delta * sin_digamma)
-            - cos_epsilon * sin_alpha * cos_beta * sin_gamma * sin_digamma
-            + cos_alpha * (-sin_epsilon * cos_delta * sin_digamma - sin_delta * cos_digamma);
-        let w2 = -sin_alpha
-            * sin_beta
-            * (-sin_epsilon * sin_delta * cos_digamma - cos_delta * sin_digamma)
-            - sin_alpha * cos_beta * sin_gamma * cos_digamma * cos_epsilon
-            + cos_alpha * (sin_delta * sin_digamma - sin_epsilon * cos_delta * cos_digamma);
-        let x3 = sin_beta * cos_gamma;
-        let y3 = cos_beta * sin_gamma * cos_epsilon - sin_epsilon * sin_beta * sin_gamma;
-        let z3 = cos_beta * (cos_delta * cos_digamma - sin_epsilon * sin_delta * sin_digamma)
-            - sin_beta * sin_gamma * sin_digamma * sin_epsilon;
-        let w3 = cos_beta * (-sin_epsilon * sin_delta * cos_digamma - cos_delta * sin_digamma)
-            - sin_beta * sin_gamma * cos_digamma * cos_epsilon;
-        let x4 = sin_gamma;
-        let y4 = sin_epsilon * cos_gamma;
-        let z4 = cos_gamma * sin_digamma * cos_epsilon;
-        let w4 = cos_gamma * cos_digamma * cos_epsilon;
-        let xr = x * x1 + y * y1 + z * z1 + w * w1;
-        let yr = x * x2 + y * y2 + z * z2 + w * w2;
-        let zr = x * x3 + y * y3 + z * z3 + w * w3;
-        let wr = x * x4 + y * y4 + z * z4 + w * w4;
+        
+        let xr = 
+        cos_alpha*(
+            x*cos_beta*cos_gamma + sin_beta*(
+                sin_delta*(
+                    sin_epsilon*(z*sin_digamma + w*cos_digamma)
+                    - y*cos_epsilon)
+                + cos_delta*(- z*cos_digamma + w*sin_digamma)
+            )
+        
+            + sin_gamma*(
+                cos_beta*(
+                    cos_epsilon*(- z*sin_digamma - w*cos_digamma)
+                    - y*sin_epsilon)
+            ))
+
+        + sin_alpha*( 
+            cos_delta*(
+                sin_epsilon*(z*sin_digamma + w*cos_digamma)
+                - y*cos_epsilon)
+            + sin_delta*(z*cos_digamma - w*sin_digamma));
+
+        let yr =
+        sin_alpha*(
+            cos_beta*(
+                sin_gamma*(
+                    cos_epsilon*(-z*sin_digamma - w*cos_digamma)
+                    - y*sin_epsilon)
+                + x*cos_gamma)
+        
+            + sin_beta*(
+                sin_delta*(
+                    sin_epsilon*(z*sin_digamma + w*cos_digamma)
+                    - y*cos_epsilon)
+                + cos_delta*(-z*cos_digamma + w*sin_digamma)))
+        
+        
+        + cos_alpha*(
+            cos_delta*(
+                sin_epsilon*(-z*sin_digamma - w*cos_digamma)
+                + y*cos_epsilon)
+            + sin_delta*(-z*cos_digamma + w*sin_digamma));
+
+        let zr = 
+        cos_beta*(
+            sin_epsilon*(
+                sin_delta*(-z*sin_digamma - w*cos_digamma))
+        
+            + cos_delta*(z*cos_digamma - w*sin_digamma)
+            + y*sin_gamma*cos_epsilon)
+        
+        + sin_beta*(
+            sin_gamma*(
+                sin_epsilon*(-y - z*sin_digamma)
+                - w*cos_digamma*cos_epsilon)
+        
+            + x*cos_gamma);
+
+        let wr = 
+        cos_gamma*(
+            cos_epsilon*(
+                z*sin_digamma + w*cos_digamma)
+            + y*sin_epsilon)
+        + x*sin_gamma;
+
         self.generator.sample([xr, yr, zr, wr])
     }
 }

--- a/src/core/adapters/rotate.rs
+++ b/src/core/adapters/rotate.rs
@@ -37,10 +37,13 @@ impl<G: Generator<2>> Generator<2> for Rotate<2, 1, G> {
     fn sample(&self, point: [f64; 2]) -> f64 {
         let x = point[0];
         let y = point[1];
+
         let sin_theta = self.rotation[0].sin();
         let cos_theta = self.rotation[0].cos();
+
         let xr = x * cos_theta - y * sin_theta;
         let yr = x * sin_theta + y * cos_theta;
+
         self.generator.sample([xr, yr])
     }
 }
@@ -50,24 +53,20 @@ impl<G: Generator<3>> Generator<3> for Rotate<3, 3, G> {
         let x = point[0];
         let y = point[1];
         let z = point[2];
-        let sin_alpha = self.rotation[0].sin();
-        let cos_alpha = self.rotation[0].cos();
-        let sin_beta = self.rotation[1].sin();
-        let cos_beta = self.rotation[1].cos();
-        let sin_gamma = self.rotation[2].sin();
-        let cos_gamma = self.rotation[2].cos();
-        let x1 = cos_beta * cos_gamma;
-        let x2 = sin_alpha * sin_beta * cos_gamma - cos_alpha * sin_gamma;
-        let x3 = cos_alpha * sin_beta * cos_gamma + sin_alpha * sin_gamma;
-        let y1 = cos_beta * sin_gamma;
-        let y2 = sin_alpha * sin_beta * sin_gamma + cos_alpha * cos_gamma;
-        let y3 = cos_alpha * sin_beta * sin_gamma - sin_alpha * cos_gamma;
-        let z1 = -sin_beta;
-        let z2 = sin_alpha * cos_beta;
-        let z3 = cos_alpha * cos_beta;
-        let xr = x * x1 + y * y1 + z * z1;
-        let yr = x * x2 + y * y2 + z * z2;
-        let zr = x * x3 + y * y3 + z * z3;
+
+        let sin_a = self.rotation[0].sin();
+        let cos_a = self.rotation[0].cos();
+
+        let sin_b = self.rotation[1].sin();
+        let cos_b = self.rotation[1].cos();
+
+        let sin_g = self.rotation[2].sin();
+        let cos_g = self.rotation[2].cos();
+        
+        let xr = cos_b*(x*cos_g + y*sin_g) + z*(-sin_b);
+        let yr = sin_a*(sin_b*(x*cos_g + y*sin_g) + z*cos_b) - cos_a*(x*sin_g - y*cos_g);
+        let zr = cos_a*(sin_b*(x*cos_g + y*sin_g) + z*cos_b) + sin_a*(x*sin_g - y*cos_g);
+
         self.generator.sample([xr, yr, zr])
     }
 }

--- a/src/core/adapters/rotate.rs
+++ b/src/core/adapters/rotate.rs
@@ -62,10 +62,12 @@ impl<G: Generator<3>> Generator<3> for Rotate<3, 3, G> {
 
         let sin_g = self.rotation[2].sin();
         let cos_g = self.rotation[2].cos();
-        
-        let xr = cos_b*(x*cos_g + y*sin_g) + z*(-sin_b);
-        let yr = sin_a*(sin_b*(x*cos_g + y*sin_g) + z*cos_b) - cos_a*(x*sin_g - y*cos_g);
-        let zr = cos_a*(sin_b*(x*cos_g + y*sin_g) + z*cos_b) + sin_a*(x*sin_g - y*cos_g);
+
+        let xr = cos_b * (x * cos_g + y * sin_g) + z * (-sin_b);
+        let yr =
+            sin_a * (sin_b * (x * cos_g + y * sin_g) + z * cos_b) - cos_a * (x * sin_g - y * cos_g);
+        let zr =
+            cos_a * (sin_b * (x * cos_g + y * sin_g) + z * cos_b) + sin_a * (x * sin_g - y * cos_g);
 
         self.generator.sample([xr, yr, zr])
     }
@@ -89,72 +91,46 @@ impl<G: Generator<4>> Generator<4> for Rotate<4, 6, G> {
         let cos_epsilon = self.rotation[4].cos();
         let sin_digamma = self.rotation[5].sin();
         let cos_digamma = self.rotation[5].cos();
-        
-        let xr = 
-        cos_alpha*(
-            x*cos_beta*cos_gamma + sin_beta*(
-                sin_delta*(
-                    sin_epsilon*(z*sin_digamma + w*cos_digamma)
-                    - y*cos_epsilon)
-                + cos_delta*(- z*cos_digamma + w*sin_digamma)
-            )
-        
-            + sin_gamma*(
-                cos_beta*(
-                    cos_epsilon*(- z*sin_digamma - w*cos_digamma)
-                    - y*sin_epsilon)
-            ))
 
-        + sin_alpha*( 
-            cos_delta*(
-                sin_epsilon*(z*sin_digamma + w*cos_digamma)
-                - y*cos_epsilon)
-            + sin_delta*(z*cos_digamma - w*sin_digamma));
+        let xr = cos_alpha
+            * (x * cos_beta * cos_gamma
+                + sin_beta
+                    * (sin_delta
+                        * (sin_epsilon * (z * sin_digamma + w * cos_digamma) - y * cos_epsilon)
+                        + cos_delta * (-z * cos_digamma + w * sin_digamma))
+                + sin_gamma
+                    * (cos_beta
+                        * (cos_epsilon * (-z * sin_digamma - w * cos_digamma) - y * sin_epsilon)))
+            + sin_alpha
+                * (cos_delta
+                    * (sin_epsilon * (z * sin_digamma + w * cos_digamma) - y * cos_epsilon)
+                    + sin_delta * (z * cos_digamma - w * sin_digamma));
 
+        let yr = sin_alpha
+            * (cos_beta
+                * (sin_gamma
+                    * (cos_epsilon * (-z * sin_digamma - w * cos_digamma) - y * sin_epsilon)
+                    + x * cos_gamma)
+                + sin_beta
+                    * (sin_delta
+                        * (sin_epsilon * (z * sin_digamma + w * cos_digamma) - y * cos_epsilon)
+                        + cos_delta * (-z * cos_digamma + w * sin_digamma)))
+            + cos_alpha
+                * (cos_delta
+                    * (sin_epsilon * (-z * sin_digamma - w * cos_digamma) + y * cos_epsilon)
+                    + sin_delta * (-z * cos_digamma + w * sin_digamma));
 
-        let yr =
-        sin_alpha*(
-            cos_beta*(
-                sin_gamma*(
-                    cos_epsilon*(-z*sin_digamma - w*cos_digamma)
-                    - y*sin_epsilon)
-                + x*cos_gamma)
-        
-            + sin_beta*(
-                sin_delta*(
-                    sin_epsilon*(z*sin_digamma + w*cos_digamma)
-                    - y*cos_epsilon)
-                + cos_delta*(-z*cos_digamma + w*sin_digamma)))
-        
-        + cos_alpha*(
-            cos_delta*(
-                sin_epsilon*(-z*sin_digamma - w*cos_digamma)
-                + y*cos_epsilon)
-            + sin_delta*(-z*cos_digamma + w*sin_digamma));
+        let zr = cos_beta
+            * (sin_epsilon * (sin_delta * (-z * sin_digamma - w * cos_digamma))
+                + cos_delta * (z * cos_digamma - w * sin_digamma)
+                + y * sin_gamma * cos_epsilon)
+            + sin_beta
+                * (sin_gamma
+                    * (sin_epsilon * (-y - z * sin_digamma) - w * cos_digamma * cos_epsilon)
+                    + x * cos_gamma);
 
-
-        let zr = 
-        cos_beta*(
-            sin_epsilon*(
-                sin_delta*(-z*sin_digamma - w*cos_digamma))
-        
-            + cos_delta*(z*cos_digamma - w*sin_digamma)
-            + y*sin_gamma*cos_epsilon)
-        
-        + sin_beta*(
-            sin_gamma*(
-                sin_epsilon*(-y - z*sin_digamma)
-                - w*cos_digamma*cos_epsilon)
-        
-            + x*cos_gamma);
-
-            
-        let wr = 
-        cos_gamma*(
-            cos_epsilon*(
-                z*sin_digamma + w*cos_digamma)
-            + y*sin_epsilon)
-        + x*sin_gamma;
+        let wr = cos_gamma * (cos_epsilon * (z * sin_digamma + w * cos_digamma) + y * sin_epsilon)
+            + x * sin_gamma;
 
         self.generator.sample([xr, yr, zr, wr])
     }

--- a/src/core/adapters/rotate.rs
+++ b/src/core/adapters/rotate.rs
@@ -111,6 +111,7 @@ impl<G: Generator<4>> Generator<4> for Rotate<4, 6, G> {
                 - y*cos_epsilon)
             + sin_delta*(z*cos_digamma - w*sin_digamma));
 
+
         let yr =
         sin_alpha*(
             cos_beta*(
@@ -125,12 +126,12 @@ impl<G: Generator<4>> Generator<4> for Rotate<4, 6, G> {
                     - y*cos_epsilon)
                 + cos_delta*(-z*cos_digamma + w*sin_digamma)))
         
-        
         + cos_alpha*(
             cos_delta*(
                 sin_epsilon*(-z*sin_digamma - w*cos_digamma)
                 + y*cos_epsilon)
             + sin_delta*(-z*cos_digamma + w*sin_digamma));
+
 
         let zr = 
         cos_beta*(
@@ -147,6 +148,7 @@ impl<G: Generator<4>> Generator<4> for Rotate<4, 6, G> {
         
             + x*cos_gamma);
 
+            
         let wr = 
         cos_gamma*(
             cos_epsilon*(

--- a/src/core/utils/visualizer.rs
+++ b/src/core/utils/visualizer.rs
@@ -245,17 +245,15 @@ fn xyz_screen_to_buff_indices(
     let mut y = y as f64;
     x -= center_x * (1.0 - scale) + scale * z as f64;
     y -= center_y;
-    
-    let yy = y / 3_f64.sqrt() - x;
-    
-    x = -(x + y / 3_f64.sqrt()) / scale + center_x;
+    let xx = -(x + y / 3_f64.sqrt());
+    let yy = 2.0 * y / 3_f64.sqrt() + xx;
+    x = xx / scale + center_x;
     y = yy / scale + center_y;
-    
     if x < 0.0 || y < 0.0 || x >= 2.0 * center_x || y >= 2.0 * center_y {
-        return None;
+        None
+    } else {
+        Some((x as usize, y as usize, z))
     }
-    
-    Some((x as usize, y as usize, z))
 }
 
 fn tensor_indices(shape: &[usize]) -> impl Iterator<Item = Vec<usize>> {

--- a/src/core/utils/visualizer.rs
+++ b/src/core/utils/visualizer.rs
@@ -157,10 +157,8 @@ impl Visualizer<3> {
         let scale = 0.45;
         let center = (self.shape[0] as f64 * 0.5, self.shape[1] as f64 * 0.5);
         let mut buf = vec![0; self.shape[0] * self.shape[1]];
-        for z_idx in (0..self.shape[2]).rev() 
-        {
-            for p in tensor_indices(&[self.shape[0], self.shape[1]]) 
-            {
+        for z_idx in (0..self.shape[2]).rev() {
+            for p in tensor_indices(&[self.shape[0], self.shape[1]]) {
                 if let Some(buf_idx) =
                     xyz_screen_to_buff_indices(p[0], p[1], z_idx, center.0, center.1, scale)
                 {
@@ -196,13 +194,10 @@ impl Visualizer<4> {
 
         let scale = 0.45;
         let center = (self.shape[0] as f64 * 0.5, self.shape[1] as f64 * 0.5);
-        for t in 0..self.shape[3]
-        {
+        for t in 0..self.shape[3] {
             let mut buf = vec![0; self.shape[0] * self.shape[1]];
-            for z_idx in (0..self.shape[2]).rev() 
-            {
-                for p in tensor_indices(&[self.shape[0], self.shape[1]]) 
-                {
+            for z_idx in (0..self.shape[2]).rev() {
+                for p in tensor_indices(&[self.shape[0], self.shape[1]]) {
                     if let Some(buf_idx) =
                         xyz_screen_to_buff_indices(p[0], p[1], z_idx, center.0, center.1, scale)
                     {

--- a/src/core/utils/visualizer.rs
+++ b/src/core/utils/visualizer.rs
@@ -157,8 +157,10 @@ impl Visualizer<3> {
         let scale = 0.45;
         let center = (self.shape[0] as f64 * 0.5, self.shape[1] as f64 * 0.5);
         let mut buf = vec![0; self.shape[0] * self.shape[1]];
-        for z_idx in (0..self.shape[2]).rev() {
-            for p in tensor_indices(&[self.shape[0], self.shape[1]]) {
+        for z_idx in (0..self.shape[2]).rev() 
+        {
+            for p in tensor_indices(&[self.shape[0], self.shape[1]]) 
+            {
                 if let Some(buf_idx) =
                     xyz_screen_to_buff_indices(p[0], p[1], z_idx, center.0, center.1, scale)
                 {
@@ -166,6 +168,7 @@ impl Visualizer<3> {
                 }
             }
         }
+
         let image = GrayImage::from_raw(self.shape[1] as u32, self.shape[0] as u32, buf).unwrap();
         image.save(path).unwrap();
     }
@@ -187,14 +190,19 @@ impl Visualizer<4> {
             .create(true)
             .open(path)
             .unwrap();
+
         let mut encoder = GifEncoder::new(file_out);
         encoder.set_repeat(Repeat::Infinite).unwrap();
+
         let scale = 0.45;
         let center = (self.shape[0] as f64 * 0.5, self.shape[1] as f64 * 0.5);
-        for t in 0..self.shape[3] {
+        for t in 0..self.shape[3]
+        {
             let mut buf = vec![0; self.shape[0] * self.shape[1]];
-            for z_idx in (0..self.shape[2]).rev() {
-                for p in tensor_indices(&[self.shape[0], self.shape[1]]) {
+            for z_idx in (0..self.shape[2]).rev() 
+            {
+                for p in tensor_indices(&[self.shape[0], self.shape[1]]) 
+                {
                     if let Some(buf_idx) =
                         xyz_screen_to_buff_indices(p[0], p[1], z_idx, center.0, center.1, scale)
                     {
@@ -203,10 +211,12 @@ impl Visualizer<4> {
                     }
                 }
             }
+
             buf = buf
                 .into_iter()
                 .flat_map(|val| std::iter::repeat(val).take(3))
                 .collect();
+
             encoder
                 .encode(
                     &buf,
@@ -235,15 +245,17 @@ fn xyz_screen_to_buff_indices(
     let mut y = y as f64;
     x -= center_x * (1.0 - scale) + scale * z as f64;
     y -= center_y;
-    let xx = -(x + y / 3_f64.sqrt());
-    let yy = 2.0 * y / 3_f64.sqrt() + xx;
-    x = xx / scale + center_x;
+    
+    let yy = y / 3_f64.sqrt() - x;
+    
+    x = -(x + y / 3_f64.sqrt()) / scale + center_x;
     y = yy / scale + center_y;
+    
     if x < 0.0 || y < 0.0 || x >= 2.0 * center_x || y >= 2.0 * center_y {
-        None
-    } else {
-        Some((x as usize, y as usize, z))
+        return None;
     }
+    
+    Some((x as usize, y as usize, z))
 }
 
 fn tensor_indices(shape: &[usize]) -> impl Iterator<Item = Vec<usize>> {


### PR DESCRIPTION
Mathematical expressions have been simplified, namely: the number of number multiplication operations has been reduced.

The speed of 4D rendering has increased by only ≈`2.5%`