### PR TITLE
major CI improvements (optional secrets, caching)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,14 +32,14 @@ jobs:
           command: install
           args: cargo-tarpaulin
       - name: run tarpaulin
-         env:
-          coveralls_token: ${{ secrets.COVERALLS_TOKEN }}
-        if: ${{ env.coveralls_token != "" }}
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        if: ${{ env.COVERALLS_TOKEN != "" }}
           uses: actions-rs/cargo@v1
           with:
             command: tarpaulin
             args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
-        if: ${{ env.coveralls_token == "" }}
+        if: ${{ env.COVERALLS_TOKEN == "" }}
           uses: actions-rs/cargo@v1
           with:
             command: tarpaulin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: test
 
 on:
+  workflow_dispatch:
   pull_request:
      branches:
       - master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} # dependency version changes in manifest should result in a new cache
       - name: install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    env:
+      COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -31,14 +33,13 @@ jobs:
         with:
           command: install
           args: cargo-tarpaulin
-      - name: run tarpaulin
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      - name: try tarpaulin with coveralls
         if: ${{ env.COVERALLS_TOKEN != "" }}
           uses: actions-rs/cargo@v1
           with:
             command: tarpaulin
             args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
+      - name: try tarpaulin without coveralls
         if: ${{ env.COVERALLS_TOKEN == "" }}
           uses: actions-rs/cargo@v1
           with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - ci-changes
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,8 +35,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: install tarpaulin
+      - name: install binstall
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+      - name: bininstall tarpaulin
         uses: actions-rs/cargo@v1
         with:
           command: binstall

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
+            target_cov
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} # dependency version changes in manifest should result in a new cache
       - name: install toolchain
         uses: actions-rs/toolchain@v1
@@ -47,13 +48,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm --skip-clean
+          args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --target-dir target_cov --engine llvm --skip-clean
       - name: try tarpaulin without coveralls
         if: ${{ env.COVERALLS_TOKEN == '' }}
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: --engine llvm --skip-clean
+          args: --target-dir target_cov --engine llvm --skip-clean
       - name: run doctests
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,9 +36,10 @@ jobs:
           toolchain: stable
           override: true
       - name: install tarpaulin
+        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         uses: actions-rs/cargo@v1
         with:
-          command: install
+          command: binstall
           args: cargo-tarpaulin
       - name: try tarpaulin with coveralls
         if: ${{ env.COVERALLS_TOKEN != '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,10 +30,18 @@ jobs:
           command: install
           args: cargo-tarpaulin
       - name: run tarpaulin
-        uses: actions-rs/cargo@v1
-        with:
-          command: tarpaulin
-          args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
+         env:
+          coveralls_token: ${{ secrets.COVERALLS_TOKEN }}
+        if: ${{ env.coveralls_token != "" }}
+          uses: actions-rs/cargo@v1
+          with:
+            command: tarpaulin
+            args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
+        if: ${{ env.coveralls_token == "" }}
+          uses: actions-rs/cargo@v1
+          with:
+            command: tarpaulin
+            args: --engine llvm
       - name: run doctests
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,16 +35,16 @@ jobs:
           args: cargo-tarpaulin
       - name: try tarpaulin with coveralls
         if: ${{ env.COVERALLS_TOKEN != "" }}
-          uses: actions-rs/cargo@v1
-          with:
-            command: tarpaulin
-            args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
+        uses: actions-rs/cargo@v1
+        with:
+          command: tarpaulin
+          args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
       - name: try tarpaulin without coveralls
         if: ${{ env.COVERALLS_TOKEN == "" }}
-          uses: actions-rs/cargo@v1
-          with:
-            command: tarpaulin
-            args: --engine llvm
+        uses: actions-rs/cargo@v1
+        with:
+          command: tarpaulin
+          args: --engine llvm
       - name: run doctests
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: binstall
-          args: cargo-tarpaulin
+          args: cargo-tarpaulin --no-confirm
       - name: try tarpaulin with coveralls
         if: ${{ env.COVERALLS_TOKEN != '' }}
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - ci-changes
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,13 +34,13 @@ jobs:
           command: install
           args: cargo-tarpaulin
       - name: try tarpaulin with coveralls
-        if: ${{ env.COVERALLS_TOKEN != "" }}
+        if: ${{ env.COVERALLS_TOKEN != '' }}
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
           args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
       - name: try tarpaulin without coveralls
-        if: ${{ env.COVERALLS_TOKEN == "" }}
+        if: ${{ env.COVERALLS_TOKEN == '' }}
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,13 +45,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm
+          args: --coveralls ${{ secrets.COVERALLS_TOKEN }} --engine llvm --skip-clean
       - name: try tarpaulin without coveralls
         if: ${{ env.COVERALLS_TOKEN == '' }}
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: --engine llvm
+          args: --engine llvm --skip-clean
       - name: run doctests
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: test
 
 on:
-  workflow_dispatch:
   pull_request:
      branches:
       - master
@@ -22,6 +21,14 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
+      - name: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: install toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Previously, running the testing CI in a fork failed due to the coveralls secret token not being available for tarpaulin coverage testing. Now, the coverage testing runs conditionally with or without the token.

Furthermore, the CI has been accelerated significantly due to usage of caching actions.