### PR TITLE
Replacing `multi_cartesian_product` to`iproduct!`

### DIFF
--- a/src/core/utils/visualizer.rs
+++ b/src/core/utils/visualizer.rs
@@ -4,7 +4,7 @@ use image::{
     codecs::gif::{GifEncoder, Repeat},
     ColorType, GrayImage,
 };
-use itertools::Itertools;
+use itertools::iproduct;
 use std::{
     fs::OpenOptions,
     ops::{Index, IndexMut},
@@ -251,9 +251,8 @@ fn xyz_screen_to_buff_indices(
     }
 }
 
-fn tensor_indices(shape: &[usize]) -> impl Iterator<Item = Vec<usize>> {
-    shape
-        .iter()
-        .map(|&dim_size| 0..dim_size)
-        .multi_cartesian_product()
+fn tensor_indices(shape: &[usize; 2]) -> Vec<[usize; 2]> {
+    iproduct!(0..shape[0], 0..shape[1])
+        .map(|(a, b)| [a, b])
+        .collect()
 }


### PR DESCRIPTION
During the test of this code:
``` rust
fn example_billow_simplex_noise3d() {
    let generator = Source::simplex(0).billow(3, 0.013, 2.0, 0.5);
    Visualizer::<3>::new([15, 15, 15], &generator).write_to_file("billow_simplex_3d.png");
}

fn example_billow_simplex_noise4d() {
    let generator = Source::simplex(0).billow(3, 0.013, 2.0, 0.5);
    Visualizer::<4>::new([15, 15, 15, 15], &generator).write_to_file("billow_simplex_4d.gif");
}
```

`iproduct!()` showed execution speed _≈16.1_%_ faster for `example_billow_simplex_noise3d` and _≈7.3_% faster for `example_billow_simplex_noise4d` compared to `multi_cartesian_product()`.

Therefore, `multi_cartesian_product()` was replaced with `iproduct!()`.
