### PR TITLE
compile faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnoise"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Contributors to the libnoise-rs Repository"]
 edition = "2021"
 license = "MIT"
@@ -17,13 +17,14 @@ dev-tools = ["dep:criterion"]
 
 [dependencies]
 num-traits = "0.2.16"
-rand = "0.8.5"
+rand_chacha = { version = "0.3.1" }
+rand = { version = "0.8.5", features = [], default-features = false }
 itertools = "0.10.5"
-image = "0.24.6"
+image = { version = "0.24.6", features = ["gif"], default-features = false, optional = true }
 criterion = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
-libnoise = { path = ".", features = ["dev-tools"] }
+libnoise = { path = ".", features = ["dev-tools", "image"] }
 criterion = "0.5.1"
 plotters = "0.3.5"
 itertools = "0.10.5"

--- a/src/core/utils/mod.rs
+++ b/src/core/utils/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod math;
 pub mod noisebuf;
 pub(super) mod ptable;
+#[cfg(feature = "image")]
 pub mod visualizer;

--- a/src/core/utils/ptable.rs
+++ b/src/core/utils/ptable.rs
@@ -1,5 +1,6 @@
 use super::math::{Vec2, Vec3, Vec4};
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::seq::SliceRandom;
+use rand_chacha::{ChaCha12Rng, rand_core::SeedableRng};
 
 #[derive(Clone, Debug)]
 pub(crate) struct PermutationTable {
@@ -9,7 +10,7 @@ pub(crate) struct PermutationTable {
 impl PermutationTable {
     pub(crate) fn new(seed: u64, w: usize, doubleup: bool) -> Self {
         let mut table = Vec::from_iter(0..w);
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = ChaCha12Rng::seed_from_u64(seed);
         table.shuffle(&mut rng);
         if doubleup {
             table.extend_from_within(..);

--- a/src/core/utils/ptable.rs
+++ b/src/core/utils/ptable.rs
@@ -1,6 +1,6 @@
 use super::math::{Vec2, Vec3, Vec4};
 use rand::seq::SliceRandom;
-use rand_chacha::{ChaCha12Rng, rand_core::SeedableRng};
+use rand_chacha::{rand_core::SeedableRng, ChaCha12Rng};
 
 #[derive(Clone, Debug)]
 pub(crate) struct PermutationTable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,4 +64,6 @@ pub use crate::core::devtools;
 pub use crate::core::generator::*;
 pub use crate::core::source::Source;
 pub use crate::core::sources::*;
-pub use crate::core::utils::{noisebuf::NoiseBuffer, visualizer::Visualizer};
+pub use crate::core::utils::noisebuf::NoiseBuffer;
+#[cfg(feature = "image")]
+pub use crate::core::utils::visualizer::Visualizer;


### PR DESCRIPTION
`crate:image` pulls in absurdly many image formats by default. `cargo build` now takes 11 packages and 4.5s; before it took 82 packages and 1m16s. `cargo test` is still pretty heavy.

Using `crate:rand::StdRng` could break reproducibility as they are allowed to change the algorithm. `Chacha12` is what they are using now.