### PR TITLE
API consistency: remove trait bounds for generics of adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnoise"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Contributors to the libnoise-rs Repository"]
 edition = "2021"
 license = "MIT"

--- a/src/core/adapters/abs.rs
+++ b/src/core/adapters/abs.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`abs()`]: Generator::abs
 #[derive(Clone, Copy, Debug)]
-pub struct Abs<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Abs<const D: usize, G> {
     generator: G,
 }
 

--- a/src/core/adapters/add.rs
+++ b/src/core/adapters/add.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`add()`]: Generator::add
 #[derive(Clone, Copy, Debug)]
-pub struct Add<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Add<const D: usize, G> {
     generator: G,
     offset: f64,
 }

--- a/src/core/adapters/billow.rs
+++ b/src/core/adapters/billow.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`billow()`]: Generator::billow
 #[derive(Clone, Copy, Debug)]
-pub struct Billow<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Billow<const D: usize, G> {
     generator: G,
     octaves: u32,
     frequency: f64,

--- a/src/core/adapters/blend.rs
+++ b/src/core/adapters/blend.rs
@@ -9,12 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`blend()`]: Generator::blend
 #[derive(Clone, Copy, Debug)]
-pub struct Blend<const D: usize, GA, GB, GC>
-where
-    GA: Generator<D>,
-    GB: Generator<D>,
-    GC: Generator<D>,
-{
+pub struct Blend<const D: usize, GA, GB, GC> {
     generator_a: GA,
     generator_b: GB,
     generator_control: GC,

--- a/src/core/adapters/clamp.rs
+++ b/src/core/adapters/clamp.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`clamp()`]: Generator::clamp
 #[derive(Clone, Copy, Debug)]
-pub struct Clamp<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Clamp<const D: usize, G> {
     generator: G,
     min: f64,
     max: f64,

--- a/src/core/adapters/displace.rs
+++ b/src/core/adapters/displace.rs
@@ -9,11 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`displace_x()`]: Generator2D::displace_x
 #[derive(Clone, Copy, Debug)]
-pub struct Displace<const D: usize, const A: usize, G, GA>
-where
-    G: Generator<D>,
-    GA: Generator<D>,
-{
+pub struct Displace<const D: usize, const A: usize, G, GA> {
     generator: G,
     displacement_generator: GA,
 }

--- a/src/core/adapters/exp.rs
+++ b/src/core/adapters/exp.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`exp()`]: Generator::exp
 #[derive(Clone, Copy, Debug)]
-pub struct Exp<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Exp<const D: usize, G> {
     generator: G,
 }
 

--- a/src/core/adapters/fbm.rs
+++ b/src/core/adapters/fbm.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`fbm()`]: Generator::fbm
 #[derive(Clone, Copy, Debug)]
-pub struct Fbm<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Fbm<const D: usize, G> {
     generator: G,
     octaves: u32,
     frequency: f64,

--- a/src/core/adapters/lambda.rs
+++ b/src/core/adapters/lambda.rs
@@ -8,11 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`lambda()`]: Generator::lambda
 #[derive(Clone, Copy, Debug)]
-pub struct Lambda<const D: usize, G, L>
-where
-    G: Generator<D>,
-    L: Fn(f64) -> f64,
-{
+pub struct Lambda<const D: usize, G, L> {
     generator: G,
     lambda: L,
 }

--- a/src/core/adapters/max.rs
+++ b/src/core/adapters/max.rs
@@ -9,11 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`max()`]: Generator::max
 #[derive(Clone, Copy, Debug)]
-pub struct Max<const D: usize, GA, GB>
-where
-    GA: Generator<D>,
-    GB: Generator<D>,
-{
+pub struct Max<const D: usize, GA, GB> {
     generator_a: GA,
     generator_b: GB,
 }

--- a/src/core/adapters/min.rs
+++ b/src/core/adapters/min.rs
@@ -9,11 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`min()`]: Generator::min
 #[derive(Clone, Copy, Debug)]
-pub struct Min<const D: usize, GA, GB>
-where
-    GA: Generator<D>,
-    GB: Generator<D>,
-{
+pub struct Min<const D: usize, GA, GB> {
     generator_a: GA,
     generator_b: GB,
 }

--- a/src/core/adapters/mul.rs
+++ b/src/core/adapters/mul.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`mul()`]: Generator::mul
 #[derive(Clone, Copy, Debug)]
-pub struct Mul<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Mul<const D: usize, G> {
     generator: G,
     scale: f64,
 }

--- a/src/core/adapters/pow.rs
+++ b/src/core/adapters/pow.rs
@@ -9,10 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 /// [`powi()`]: Generator::powi
 /// [`powf()`]: Generator::powf
 #[derive(Clone, Copy, Debug)]
-pub struct Pow<const D: usize, G, T>
-where
-    G: Generator<D>,
-{
+pub struct Pow<const D: usize, G, T> {
     generator: G,
     exponent: T,
 }

--- a/src/core/adapters/power.rs
+++ b/src/core/adapters/power.rs
@@ -9,11 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`power()`]: Generator::power
 #[derive(Clone, Copy, Debug)]
-pub struct Power<const D: usize, GA, GB>
-where
-    GA: Generator<D>,
-    GB: Generator<D>,
-{
+pub struct Power<const D: usize, GA, GB> {
     generator_a: GA,
     generator_b: GB,
 }

--- a/src/core/adapters/ridgedmulti.rs
+++ b/src/core/adapters/ridgedmulti.rs
@@ -9,10 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 /// [`fbm()`]: Generator:fbm
 /// [`ridgedmulti()`]: Generator::ridgedmulti
 #[derive(Clone, Copy, Debug)]
-pub struct RidgedMulti<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct RidgedMulti<const D: usize, G> {
     generator: G,
     octaves: u32,
     frequency: f64,

--- a/src/core/adapters/rotate.rs
+++ b/src/core/adapters/rotate.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator2D, Generator3D, Generator4D};
 ///
 /// [`rotate()`]: Generator2D::rotate
 #[derive(Clone, Copy, Debug)]
-pub struct Rotate<const D: usize, const P: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Rotate<const D: usize, const P: usize, G> {
     generator: G,
     rotation: [f64; P],
 }

--- a/src/core/adapters/scale.rs
+++ b/src/core/adapters/scale.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`scale()`]: Generator::scale
 #[derive(Clone, Copy, Debug)]
-pub struct Scale<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Scale<const D: usize, G> {
     generator: G,
     scale: [f64; D],
 }

--- a/src/core/adapters/select.rs
+++ b/src/core/adapters/select.rs
@@ -10,12 +10,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`select()`]: Generator::select
 #[derive(Clone, Copy, Debug)]
-pub struct Select<const D: usize, GA, GB, GC>
-where
-    GA: Generator<D>,
-    GB: Generator<D>,
-    GC: Generator<D>,
-{
+pub struct Select<const D: usize, GA, GB, GC> {
     generator_a: GA,
     generator_b: GB,
     generator_control: GC,

--- a/src/core/adapters/sum.rs
+++ b/src/core/adapters/sum.rs
@@ -9,11 +9,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`sum()`]: Generator::sum
 #[derive(Clone, Copy, Debug)]
-pub struct Sum<const D: usize, GA, GB>
-where
-    GA: Generator<D>,
-    GB: Generator<D>,
-{
+pub struct Sum<const D: usize, GA, GB> {
     generator_a: GA,
     generator_b: GB,
 }

--- a/src/core/adapters/translate.rs
+++ b/src/core/adapters/translate.rs
@@ -8,10 +8,7 @@ use crate::core::generator::{Generator, Generator1D, Generator2D, Generator3D, G
 ///
 /// [`translate()`]: Generator::translate
 #[derive(Clone, Copy, Debug)]
-pub struct Translate<const D: usize, G>
-where
-    G: Generator<D>,
-{
+pub struct Translate<const D: usize, G> {
     generator: G,
     translation: [f64; D],
 }


### PR DESCRIPTION
remove trait bounds for generics of adapters, they are only present in impl-blocks