### PR TITLE
Use the default features of the image crate when the image feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ categories = ["algorithms", "mathematics", "game-development", "graphics"]
 
 [features]
 dev-tools = ["dep:criterion"]
+image = ["dep:image"]
 
 [dependencies]
 num-traits = "0.2.16"
 rand_chacha = { version = "0.3.1" }
 rand = { version = "0.8.5", features = [], default-features = false }
 itertools = "0.10.5"
-image = { version = "0.24.6", features = ["gif"], default-features = false, optional = true }
+image = { version = "0.24.6", features = ["gif"], optional = true }
 criterion = { version = "0.5.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Using the `Visualizer` caused an error when using this crate as a dependency with the `image` feature, because while the `image` crate does get added as a dependency, it gets added without the default features which correspond to saving the most common image file types (png, jpeg, tiff, etc.).

This can be fixed by using adding the `image` crate as a dependency of the `image` feature and making it so the default features are enabled. This means that if this feature isn't enabled, it won't add any unnecessary crates.

But now it will set the correct features of the `image` crate if it is enabled.